### PR TITLE
docs(readme): Fix missing GH Actions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You're free to customize sites that you create with this template, however you l
 [Jekyll]: https://jekyllrb.com
 [Just the Docs]: https://just-the-docs.github.io/just-the-docs/
 [GitHub Pages]: https://docs.github.com/en/pages
+[GitHub Pages / Actions workflow]: https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/
 [Bundler]: https://bundler.io
 [use this template]: https://github.com/just-the-docs/just-the-docs-template/generate
 [`jekyll-default-layout`]: https://github.com/benbalter/jekyll-default-layout


### PR DESCRIPTION
Adds a reference-style link borrowed from index.md to fix missing link in README.md