### PR TITLE
Add instructions for building project as part of an existing repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ More specifically, the created site:
 
 To get started with creating a site, just click "[use this template]"!
 
+If you want to maintain your docs in the `docs` directory of an existing project repo, see [Hosting your docs from an existing project repo](#hosting-your-docs-from-an-existing-project-repo).
+
 After completing the creation of your new site on GitHub, update it as needed:
 
 ## Replace the content of the template pages
@@ -89,6 +91,71 @@ Just upload all the files in the directory `_site`.
 You're free to customize sites that you create with this template, however you like!
 
 [Browse our documentation][Just the Docs] to learn more about how to use this theme.
+
+## Hosting your docs from an existing project repo
+
+You might want to maintain your docs in an existing project repo. Instead of creating a new repo using the [just-the-docs template](https://github.com/just-the-docs/just-the-docs-template), you can copy the template files into your existing repo and configure the template's Github Actions workflow to build from a `docs` directory. You can clone the template to your local machine or download the `.zip` file to access the files.
+
+### Copy the template files
+
+1.  Create a `.github/workflows` directory at your project root if your repo doesn't already have one. Copy the `pages.yml` file into this directory. Github Actions searches this directory for workflow files.
+
+2.  Create a `docs` directory at your project root and copy all remaining template files into this directory.
+
+### Modify the Github Actions worklow
+
+The Github Actions workflow that builds and deploys your site to Github Pages is defined by the `pages.yml` file. You'll need to edit this file to that so that your build and deploy steps look to your `docs` directory, rather than the project root.
+
+1.  Set the default `working-directory` param for the build job.
+
+    ```yaml
+    build:
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: docs
+    ```
+
+2.  Set the `working-directory` param for the Setup Ruby step.
+
+    ```yaml
+    - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          cache-version: 0
+          working-directory: '${{ github.workspace }}/docs'
+    ```
+
+3.  Set the path param for the Upload artifact step:
+
+    ```yaml
+    - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "docs/_site/"
+    ```
+
+4.  Modify the trigger so that only changes within the `docs` directory start the workflow. Otherwise, every change to your project (even those that don't affect the docs) would trigger a new site build and deploy.
+
+    ```yaml
+    on:
+      push:
+        branches:
+          - "main"
+        paths:
+          - "docs/**"
+    ```
+
+
+
+
+
+### Configure 
+
+create a docs folder in your project repo, and copy all the template files, excluding the `.githubinto that folder. I
+
 
 ## Licensing and Attribution
 

--- a/README.md
+++ b/README.md
@@ -148,15 +148,6 @@ The Github Actions workflow that builds and deploys your site to Github Pages is
           - "docs/**"
     ```
 
-
-
-
-
-### Configure 
-
-create a docs folder in your project repo, and copy all the template files, excluding the `.githubinto that folder. I
-
-
 ## Licensing and Attribution
 
 This repository is licensed under the [MIT License]. You are generally free to reuse or extend upon this code as you see fit; just include the original copy of the license (which is preserved when you "make a template"). While it's not necessary, we'd love to hear from you if you do use this template, and how we can improve it for future use!

--- a/index.md
+++ b/index.md
@@ -18,6 +18,8 @@ Other than that, you're free to customize sites that you create with this templa
 
 To get started with creating a site, just click "[use this template]"!
 
+If you want to maintain your docs in the `docs` directory of an existing project repo, see [Hosting your docs from an existing project repo](https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md#hosting-your-docs-from-an-existing-project-repo) in the template README.
+
 ----
 
 [^1]: [It can take up to 10 minutes for changes to your site to publish after you push the changes to GitHub](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll#creating-your-site).


### PR DESCRIPTION
Per [discussion 1183](https://github.com/just-the-docs/just-the-docs/discussions/1183), I've updated the template docs to include the steps I took to get my site to build from my project's `docs` directory.

- I create a section called "Hosting your docs from an existing project repo" in the project README detailing necessary modifications to the pages.yml file.
- I linked to this new section near top of the README to redirect interested users
- I linked to this new section from index.md