### PR TITLE
Enable dependabot updates for theme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
-    schedule: daily
+    schedule:
+      interval: daily
     allow:
-      dependency-type: direct
-   
+      - dependency-type: direct

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule: daily
+    allow:
+      dependency-type: direct
+   


### PR DESCRIPTION
This workflow will semi-automatically update just the docs in the gemfile and the corresponding lock-file.

This doesn't only keep the template updated, it will also create PRs for every repository derived from this template.

Example PR: https://github.com/max06/just-the-docs-template/pull/2

A change to the `README.md` will come soon, this feature needs a settings change in the created repository.

@just-the-docs/maintainers I'd love to hear your opinions!