### PR TITLE
Fix missing docs step (enable GitHub Actions as deploy source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ More specifically, the created site:
 - uses a gem-based approach, i.e. uses a `Gemfile` and loads the `just-the-docs` gem;
 - uses the [GitHub Pages / Actions workflow] to build and publish the site on GitHub Pages.
 
-To get started with creating a site, just click "[use this template]"!
+To get started with creating a site, simply:
+
+1. click "[use this template]" to create a GitHub repository
+2. go to Settings > Pages > Build and deployment > Source, and select GitHub Actions
 
 If you want to maintain your docs in the `docs` directory of an existing project repo, see [Hosting your docs from an existing project repo](#hosting-your-docs-from-an-existing-project-repo).
 

--- a/index.md
+++ b/index.md
@@ -16,7 +16,10 @@ Other than that, you're free to customize sites that you create with this templa
 
 [Browse our documentation][Just the Docs] to learn more about how to use this theme.
 
-To get started with creating a site, just click "[use this template]"!
+To get started with creating a site, simply:
+
+1. click "[use this template]" to create a GitHub repository
+2. go to Settings > Pages > Build and deployment > Source, and select GitHub Actions
 
 If you want to maintain your docs in the `docs` directory of an existing project repo, see [Hosting your docs from an existing project repo](https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md#hosting-your-docs-from-an-existing-project-repo) in the template README.
 


### PR DESCRIPTION
I've been meaning to do this for a while, but haven't gotten around to it! This PR adds the missing step of having to explicitly enable GitHub Actions as the build source for GitHub Pages. 

Open to suggestions on better copy!

This closes #17 (and various other issues/discussions about this template not working properly).