### PR TITLE
Add copy of Starter Workflows’s license

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,30 @@ The GitHub Actions workflow that builds and deploys your site to Github Pages is
 
 This repository is licensed under the [MIT License]. You are generally free to reuse or extend upon this code as you see fit; just include the original copy of the license (which is preserved when you "make a template"). While it's not necessary, we'd love to hear from you if you do use this template, and how we can improve it for future use!
 
-The deployment GitHub Actions workflow is heavily based on GitHub's mixed-party [starter workflows]. A copy of their MIT License is available in [actions/starter-workflows].
+The deployment GitHub Actions workflow is heavily based on GitHub's mixed-party [starter workflows]. Here’s a copy of [their MIT License]:
+
+> MIT License
+> 
+> Copyright (c) 2020 GitHub
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE. THIS LICENSE DOES NOT GRANT YOU RIGHTS TO USE ANY CONTRIBUTORS'
+> NAME, LOGO, OR TRADEMARKS.
 
 ----
 
@@ -171,4 +194,4 @@ The deployment GitHub Actions workflow is heavily based on GitHub's mixed-party 
 [`jekyll-seo-tag`]: https://jekyll.github.io/jekyll-seo-tag
 [MIT License]: https://en.wikipedia.org/wiki/MIT_License
 [starter workflows]: https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml
-[actions/starter-workflows]: https://github.com/actions/starter-workflows/blob/main/LICENSE
+[their MIT License]: https://github.com/actions/starter-workflows/blob/main/LICENSE


### PR DESCRIPTION
GitHub’s starter-workflows repo is available under the MIT License. The MIT License says:

> The above copyright notice and this permission notice shall be included in all
> copies or substantial portions of the Software.

Before this commit, the just-the-docs-template repo did not include a copy of the start-workflows repo’s version of the MIT License. It contained a link to the starter-workflows repo’s LICNESE file[, but a link is not good enough. You need to include an actual copy of the licnese and copyright notice][1].

Before this commit, we did actually include a copy of the MIT License because this repo itself is available under the MIT License. Unfortunately, the version of the MIT License that this repo uses is different than the version of the MIT License that the starter-workflows repo uses. Additionally, we did not include the copyright notice for the starter-workflows repo at all before this commit.

[1]: <https://writing.kemitchell.com/2019/03/09/Deprecation-Notice.html#mit-and-bsd-breed-confusion>