### PR TITLE
indicate use of baseurl configuration for Github Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Note: If you are using a Jekyll version less than 3.5.0, use the `gems` key inst
     description: YOUR DESCRIPTION
     theme: just-the-docs
 
-    url: https://YOUR-USERNAME.github.io/YOUR-SITE-NAME
+    url: https://YOUR-USERNAME.github.io
+    baseurl: YOUR-SITE-NAME # baseurl is used by Jekyll when serving from a subfolder
 
     aux_links: # remove if you don't want this link to appear on your pages
       Template Repository: https://github.com/YOUR-USERNAME/YOUR-SITE-NAME

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: A starter template for a Jeykll site using the Just the Docs theme!
 theme: just-the-docs
 
 url: https://just-the-docs.github.io
+baseurl: ''
 
 aux_links:
   Template Repository: https://github.com/just-the-docs/just-the-docs-template


### PR DESCRIPTION
I have been learning Jekyll and Just the Docs recently, thank you for this very helpful template. Based on my experience customizing Just the Docs, my intention with this PR is to bring the Just the Docs README and default configuration closer to the approach recommended by Jekyll. 

If I understand Jekyll correctly, when a site is going to be served from a subfolder, the `baseurl` parameter should be set in `_config.yml`. Jekyll resources often specifically name a Github Pages deployment as an example of a situation when baseurl should be used.

So if I have a github repo named `cushaw-handbook` that I am deploying via Github Pages, I believe that the correct Jekyll configuration would include:
```
url: https://markwkidd.github.io
baseurl: cushaw-handbook
```

In my situation this is relevant to image processing and styling. With `baseurl` set, I can now use functionality Jekyll's `relative_url` function in my content:
```
![Drying seeds in a colendar just removed from cushaw fruit]( {{ '/assets/images/recipes/cut-fruit-with-seeds-350w.jpg' | relative_url }} )
```

I also use an include to use `figcaption` to display image captions in content areas. With `baseurl` set for my Github Pages deployment, I can create an `_image.html` like this:
```
<figure>
    <img src="{{ site.baseurl include.url }}" alt="{{ include.description }}">
    <figcaption>{{ include.description }}</figcaption>
</figure>
```

I can invoke this template with:
```
{% include image.html url="/{{assets/images/recipes/cut-fruit-with-seeds-350w.jpg" description="Seed saving and sharing is integrated into the guide" %}
```

Thank you for considering this patch.